### PR TITLE
Reduce message character limit from 250 to 200 in Message.cs

### DIFF
--- a/src/Application/src/RazorPagesTestSample/Data/Message.cs
+++ b/src/Application/src/RazorPagesTestSample/Data/Message.cs
@@ -9,7 +9,7 @@ namespace RazorPagesTestSample.Data
 
         [Required]
         [DataType(DataType.Text)]
-        [StringLength(250, ErrorMessage = "There's a 250 character limit on messages. Please shorten your message.")]
+        [StringLength(200, ErrorMessage = "There's a 200 character limit on messages. Please shorten your message.")]
         public string Text { get; set; }
     }
     #endregion


### PR DESCRIPTION
This pull request includes a change to the `Message` class in the `RazorPagesTestSample` project, specifically modifying the character limit for the `Text` property.

* [`src/Application/src/RazorPagesTestSample/Data/Message.cs`](diffhunk://#diff-3ce635672d23bd9cdaa8656d8d117fc07bbea38b87de905339a765df73f3c450L12-R12): Reduced the character limit for the `Text` property from 250 to 200 characters.