### PR TITLE
Rename .NET workflow to ".NET CI" and create a new ".NET CD" workflow

### DIFF
--- a/.github/workflows/dotnetCD.yml
+++ b/.github/workflows/dotnetCD.yml
@@ -1,0 +1,123 @@
+name: .NET CD
+
+env:
+  registryName: rltuztndcef7cmpnpreg.azurecr.io
+  repositoryName: techexcel/dotnetcoreapp
+  dockerFolderPath: ./src/Application/src/RazorPagesTestSample
+  tag: ${{github.run_number}}
+
+on:
+  push:
+    branches: [ main ]
+    paths: src/Application/**
+  # pull_request:
+  #   branches: [ main ]
+  #   paths: src/Application/**
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Setup .NET
+      uses: actions/setup-dotnet@v3
+      with:
+        dotnet-version: 8.0
+    
+    - name: Restore dependencies
+      run: dotnet restore ./src/Application/src/RazorPagesTestSample/RazorPagesTestSample.csproj
+    - name: Build
+      run: dotnet build --no-restore ./src/Application/src/RazorPagesTestSample/RazorPagesTestSample.csproj
+    - name: Test
+      run: dotnet test --no-build --verbosity normal ./src/Application/tests/RazorPagesTestSample.Tests/RazorPagesTestSample.Tests.csproj
+      
+  dockerBuildPush:
+    runs-on: ubuntu-latest
+    needs: build
+
+    steps:
+    - uses: actions/checkout@v3
+    
+    - name: Docker Login
+      # You may pin to the exact commit or the version.
+      # uses: docker/login-action@28218f9b04b4f3f62068d7b6ce6ca5b26e35336c
+      uses: docker/login-action@v1.9.0
+      with:
+        # Server address of Docker registry. If not set then will default to Docker Hub
+        registry: ${{ secrets.ACR_LOGIN_SERVER }}
+        # Username used to log against the Docker registry
+        username: ${{ secrets.ACR_USERNAME }}
+        # Password or personal access token used to log against the Docker registry
+        password: ${{ secrets.ACR_PASSWORD }}
+        # Log out from the Docker registry at the end of a job
+        logout: true
+        
+    - name: Docker Build
+      run: docker build -t $registryName/$repositoryName:$tag --build-arg build_version=$tag $dockerFolderPath
+      
+    - name: Docker Push
+      run: docker push $registryName/$repositoryName:$tag
+
+  deploy-to-dev:
+  
+    runs-on: ubuntu-latest
+    needs: dockerBuildPush
+    environment:
+      name: dev
+      url: https://rltuztndcef7c-dev.azurewebsites.net/
+    
+    steps:
+      - name: 'Login via Azure CLI'
+        uses: azure/login@v2.1.1
+        with:
+          creds: ${{ secrets.AZURE_CREDENTIALS }}
+
+      - uses: azure/webapps-deploy@v2
+        with:
+          app-name: 'rltuztndcef7c-dev'
+          images: rltuztndcef7cmpnpreg.azurecr.io/techexcel/dotnetcoreapp:${{github.run_number}}
+
+  deploy-to-test:
+  
+    runs-on: ubuntu-latest
+    needs: deploy-to-dev
+    environment:
+      name: test
+      url: https://rltuztndcef7c-test.azurewebsites.net/
+    
+    steps:
+    - uses: actions/checkout@v3
+    
+    - name: 'Login via Azure CLI'
+      uses: azure/login@v2.1.1
+      with:
+        creds: ${{ secrets.AZURE_CREDENTIALS }}
+
+    - uses: azure/webapps-deploy@v2
+      with:
+        app-name: 'rltuztndcef7c-test'
+        images: rltuztndcef7cmpnpreg.azurecr.io/techexcel/dotnetcoreapp:${{github.run_number}}
+
+  deploy-to-prod:
+  
+    runs-on: ubuntu-latest
+    needs: deploy-to-test
+    environment:
+      name: prod
+      url: https://rltuztndcef7c-prod.azurewebsites.net/
+    
+    steps:
+    - uses: actions/checkout@v3
+    
+    - name: 'Login via Azure CLI'
+      uses: azure/login@v2.1.1
+      with:
+        creds: ${{ secrets.AZURE_CREDENTIALS }}
+
+    - uses: azure/webapps-deploy@v2
+      with:
+        app-name: 'rltuztndcef7c-prod'
+        images: rltuztndcef7cmpnpreg.azurecr.io/techexcel/dotnetcoreapp:${{github.run_number}}

--- a/.github/workflows/dotnetCI.yml
+++ b/.github/workflows/dotnetCI.yml
@@ -1,4 +1,4 @@
-name: .NET CD
+name: .NET CI
 
 env:
   registryName: rltuztndcef7cmpnpreg.azurecr.io
@@ -7,9 +7,9 @@ env:
   tag: ${{github.run_number}}
 
 on:
-  push:
-    branches: [ main ]
-    paths: src/Application/**
+  # push:
+  #   branches: [ main ]
+  #   paths: src/Application/**
   pull_request:
     branches: [ main ]
     paths: src/Application/**
@@ -58,66 +58,7 @@ jobs:
     - name: Docker Build
       run: docker build -t $registryName/$repositoryName:$tag --build-arg build_version=$tag $dockerFolderPath
       
-    - name: Docker Push
-      run: docker push $registryName/$repositoryName:$tag
+    # - name: Docker Push
+    #   run: docker push $registryName/$repositoryName:$tag
 
-  deploy-to-dev:
   
-    runs-on: ubuntu-latest
-    needs: dockerBuildPush
-    environment:
-      name: dev
-      url: https://rltuztndcef7c-dev.azurewebsites.net/
-    
-    steps:
-      - name: 'Login via Azure CLI'
-        uses: azure/login@v2.1.1
-        with:
-          creds: ${{ secrets.AZURE_CREDENTIALS }}
-
-      - uses: azure/webapps-deploy@v2
-        with:
-          app-name: 'rltuztndcef7c-dev'
-          images: rltuztndcef7cmpnpreg.azurecr.io/techexcel/dotnetcoreapp:${{github.run_number}}
-
-  deploy-to-test:
-  
-    runs-on: ubuntu-latest
-    needs: deploy-to-dev
-    environment:
-      name: test
-      url: https://rltuztndcef7c-test.azurewebsites.net/
-    
-    steps:
-    - uses: actions/checkout@v3
-    
-    - name: 'Login via Azure CLI'
-      uses: azure/login@v2.1.1
-      with:
-        creds: ${{ secrets.AZURE_CREDENTIALS }}
-
-    - uses: azure/webapps-deploy@v2
-      with:
-        app-name: 'rltuztndcef7c-test'
-        images: rltuztndcef7cmpnpreg.azurecr.io/techexcel/dotnetcoreapp:${{github.run_number}}
-
-  deploy-to-prod:
-  
-    runs-on: ubuntu-latest
-    needs: deploy-to-test
-    environment:
-      name: prod
-      url: https://rltuztndcef7c-prod.azurewebsites.net/
-    
-    steps:
-    - uses: actions/checkout@v3
-    
-    - name: 'Login via Azure CLI'
-      uses: azure/login@v2.1.1
-      with:
-        creds: ${{ secrets.AZURE_CREDENTIALS }}
-
-    - uses: azure/webapps-deploy@v2
-      with:
-        app-name: 'rltuztndcef7c-prod'
-        images: rltuztndcef7cmpnpreg.azurecr.io/techexcel/dotnetcoreapp:${{github.run_number}}


### PR DESCRIPTION
This pull request includes significant changes to the GitHub Actions workflows for the .NET project. The changes involve renaming a workflow file, modifying the triggers for an existing workflow, and adding a new continuous integration workflow.

Workflow file modifications:

* [`.github/workflows/dotnetCD.yml`](diffhunk://#diff-e8c1116b74d499ed002ed204bb98b9db4560551a02d8e077ad1d0768387690eeL13-R15): Renamed from `.github/workflows/dotnet.yml` and commented out the `pull_request` trigger.

New continuous integration workflow:

* [`.github/workflows/dotnetCI.yml`](diffhunk://#diff-8f4269538fda8a8f511663d2c29b82c8b7be7576556bb0d0db0d5f51a5d79411R1-R64): Added a new workflow for .NET CI, which includes environment variables, triggers for `pull_request` and `workflow_dispatch`, and jobs for building, testing, and building Docker images.