### PR TITLE
Fix character limit error message for message text field

### DIFF
--- a/src/Application/src/RazorPagesTestSample/Data/Message.cs
+++ b/src/Application/src/RazorPagesTestSample/Data/Message.cs
@@ -9,7 +9,7 @@ namespace RazorPagesTestSample.Data
 
         [Required]
         [DataType(DataType.Text)]
-        [StringLength(250, ErrorMessage = "There's a 250 character limit on messages. Please shorten your message.")]
+        [StringLength(200, ErrorMessage = "There's a 20S0 character limit on messages. Please shorten your message.")]
         public string Text { get; set; }
     }
     #endregion


### PR DESCRIPTION
This pull request includes a minor change to the `Message` class in the `src/Application/src/RazorPagesTestSample/Data/Message.cs` file. The change reduces the maximum allowed length of the `Text` property from 250 characters to 200 characters.

* [`src/Application/src/RazorPagesTestSample/Data/Message.cs`](diffhunk://#diff-3ce635672d23bd9cdaa8656d8d117fc07bbea38b87de905339a765df73f3c450L12-R12): Reduced the maximum allowed length of the `Text` property from 250 characters to 200 characters.

#8 